### PR TITLE
Automate the Docker image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ The changes below assume that you are dockerizing an entire repository. However,
 * To work with Tensorflow on a GPU instance, change the top line to `FROM tensorflow/tensorflow:latest-gpu-py3`
 
 #### script/app-env
-* Change `DOCKER_IMAGE` name to match your repo name, or the name of the containing directory (line 10)
-* Change `appdir:/src` to `appdir:/your-top-dir` (lines 14 & 16)
+* (OPTIONAL) Change `DOCKER_IMAGE` name if you want (line 11). By default it is given the name of the directory containing the `Dockerfile`
+* Change `appdir:/src` to `appdir:/your-top-dir` (lines 15 & 17)
 * To run with GPU (see change to Dockerfile also), you will need to change the last line to use nvidia, like `exec docker run --runtime=nvidia -i -t -v "$appdir:/src" $image $cmd`
 * You can also use environment variables like below (assumes they are stored in the `script/` directory in a `.env` file),
     ```
@@ -24,7 +24,7 @@ The changes below assume that you are dockerizing an entire repository. However,
     ```
 
 #### script/bootstrap
-* Change the final name to your repo name - make sure to leave a space between the repo name and the final period (line 7)
+* (OPTIONAL) Change the image name if you want (line 8). If you do, make sure to leave a space between the image name and the final period. By default the name of the directory containing the `Dockerfile` is used.
 
 #### script/cibuild-verify-image
 No changes needed

--- a/script/app-env
+++ b/script/app-env
@@ -3,11 +3,12 @@
 
 set -e
 
+imagename=$(basename $PWD)
 appdir=$(cd $(dirname "$0")/.. && pwd)
 [ -f /etc/inside-container ] && exec "$@"
 
 cmd="$@"; [ "$#" -eq 0 ] && cmd=bash
-image=${DOCKER_IMAGE:=docker-template}
+image=${DOCKER_IMAGE:=$imagename}
 
 if [ ! -f script/.env ]; then
     echo "Environment variables file (script/.env) not found!"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -3,5 +3,6 @@
 set -e
 
 appdir=$(cd $(dirname "$0")/.. && pwd)
+imagename=$(basename $PWD)
 
-cd "$appdir" && docker build -t docker-template .
+cd "$appdir" && docker build -t $imagename .


### PR DESCRIPTION
This PR automatically creates the image name out of the top-level directory (the one containing the `Dockerfile`. This saves a couple steps when using this template.